### PR TITLE
core stall added

### DIFF
--- a/src/main/scala/components/Top.scala
+++ b/src/main/scala/components/Top.scala
@@ -10,6 +10,7 @@ class Top(programFile:Option[String]) extends Module{
   val io = IO(new Bundle() {
     val pin = Output(UInt(32.W))
     val rvfi = new RVFIPORT
+    val stall = Input(Bool())
   })
 
   implicit val config = WishboneConfig(32, 32) //WishboneConfig(32,32)
@@ -36,7 +37,7 @@ class Top(programFile:Option[String]) extends Module{
 
   io.rvfi <> core.io.rvfi
   io.pin := core.io.pin
-
+  core.io.stall := io.stall
 }
 //class Top(programFile:Option[String]) extends Module{
 //  val io = IO(new Bundle() {

--- a/src/test/scala/components/TopTest.scala
+++ b/src/test/scala/components/TopTest.scala
@@ -25,7 +25,8 @@ class TopTest extends FreeSpec with ChiselScalatestTester {
       // test(new Top(new WBRequest(), new WBResponse(), Module(new WishboneAdapter()), Module(new WishboneAdapter()), programFile)).withAnnotation(Seq(VerilatorBackendAnnotation)){ c =>
         test(new Top(programFile)).withAnnotations(Seq(VerilatorBackendAnnotation)){ c =>
           c.clock.setTimeout(0)
-          c.clock.step(10000)
+          // c.io.stall.poke(true.B)
+          c.clock.step(1000)
       }
   }
 }


### PR DESCRIPTION
```
io.stall := Bool()
```
is used to stall the core.
It helps us when we are using programming uart to program the ICCM and want to stall the core.