### PR TITLE
RISC-V Compressed Extension support

### DIFF
--- a/src/main/scala/components/CompressedDecoder.scala
+++ b/src/main/scala/components/CompressedDecoder.scala
@@ -1,0 +1,290 @@
+/*
+  Created by @Abdulwadodd as part of Google Summer of Code program 2022.
+  
+  Description:
+  This decoder decodes all RISC-V Compressed (16-bit) Instructions into 
+  its 32-bit equivalent instructions.
+  Whenever the compressed instruction is encountered, 
+  it sets the is_comp signal which is responsible for selecting
+  the increment of PC by 2 rather than 4. */
+
+package nucleusrv.components
+import chisel3._
+import chisel3.util._ 
+
+class CompressedDecoder extends Module {
+  val io = IO(new Bundle {
+    //Input
+    val instruction_i = Input(UInt(32.W))
+    // Outputs
+    val is_comp = Output(Bool())
+    val instruction_o = Output(UInt(32.W))
+  })
+
+  val OPCODE_LOAD   = "h03".asUInt(7.W)
+  val OPCODE_OP_IMM = "h13".asUInt(7.W)
+  val OPCODE_STORE  = "h23".asUInt(7.W)
+  val OPCODE_OP     = "h33".asUInt(7.W)
+  val OPCODE_LUI    = "h37".asUInt(7.W) 
+  val OPCODE_BRANCH = "h63".asUInt(7.W)
+  val OPCODE_JALR   = "h67".asUInt(7.W)
+  val OPCODE_JAL    = "h6f".asUInt(7.W)
+
+  //Default values
+  io.is_comp := false.B 
+  io.instruction_o := io.instruction_i 
+
+  switch (io.instruction_i(1,0)) {
+
+    // C0
+    is ("b00".U) {
+
+      switch (io.instruction_i(15, 14)) {
+
+        is ("b00".U) { 
+          // c.addi4spn -> addi rd', x2, imm
+          io.is_comp := true.B
+          io.instruction_o := Cat("b00".asUInt(2.W), io.instruction_i(10, 7), io.instruction_i(12, 11), io.instruction_i(5), 
+                              io.instruction_i(6),"b00".asUInt(2.W),"h02".asUInt(5.W), "b000".asUInt(3.W), "b01".asUInt(2.W), io.instruction_i(4, 2),OPCODE_OP_IMM)
+        }
+
+        is ("b01".U) {
+          // c.lw -> lw rd', imm(rs1')
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(5,"b0".U), io.instruction_i(5), io.instruction_i(12, 10), io.instruction_i(6),
+                              "b0001".asUInt(4.W), io.instruction_i(9,7),"b010".asUInt(3.W),"b01".asUInt(2.W), io.instruction_i(4, 2), OPCODE_LOAD)
+        }
+
+        is ("b11".U) {
+          // c.sw -> sw rs2', imm(rs1')
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(5,"b0".U), io.instruction_i(5), io.instruction_i(12), "b01".asUInt(2.W), io.instruction_i(4,2),
+                              "b01".asUInt(2.W), io.instruction_i(9,7),"b010".asUInt(3.W), io.instruction_i(11, 10), io.instruction_i(6), "b00".asUInt(2.W), OPCODE_STORE)
+        }
+
+        is ("b10".U) {
+          // illegal instruction
+          io.is_comp := false.B
+          io.instruction_o := io.instruction_i
+        }
+      }
+    }
+
+    // C1
+
+    // Register address checks for RV32E are performed in the regular instruction decoder.
+    // If this check fails, an illegal instruction exception is triggered and the controller
+    // writes the actual faulting instruction to mtval.
+    is ("b01".U) {
+
+      switch (io.instruction_i(15, 13)) {
+
+        is ("b000".U) {
+          // c.addi -> addi rd, rd, nzimm
+          // c.nop
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(6,io.instruction_i(12)), io.instruction_i(12), io.instruction_i(6,2),
+                              io.instruction_i(11,7),"b000".asUInt(3.W), io.instruction_i(11, 7), OPCODE_OP_IMM)
+        }
+        
+        is ("b001".U) {
+          // 001: c.jal -> jal x1, imm   
+          io.is_comp := true.B
+          io.instruction_o := Cat(io.instruction_i(12), io.instruction_i(8), io.instruction_i(10,9), io.instruction_i(6),
+                              io.instruction_i(7),io.instruction_i(2), io.instruction_i(11), io.instruction_i(5,3), 
+                              Fill(9,io.instruction_i(12)), "b0000".asUInt(4.W), ~io.instruction_i(15), OPCODE_JAL)
+        }
+
+        is ("b101".U) {
+          // 101: c.j   -> jal x0, imm
+          io.is_comp := true.B
+          io.instruction_o := Cat(io.instruction_i(12), io.instruction_i(8), io.instruction_i(10,9), io.instruction_i(6),
+                              io.instruction_i(7),io.instruction_i(2), io.instruction_i(11), io.instruction_i(5,3), 
+                              Fill(9,io.instruction_i(12)), "b0000".asUInt(4.W), ~io.instruction_i(15), OPCODE_JAL)
+        }
+        
+        is ("b010".U) {
+          // c.li -> addi rd, x0, nzimm
+          // (c.li hints are translated into an addi hint)
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(6,io.instruction_i(12)), io.instruction_i(12), io.instruction_i(6,2), "b00000".asUInt(5.W),
+                              "b000".asUInt(3.W), io.instruction_i(11,7), OPCODE_OP_IMM)          
+        }
+
+        is ("b011".U) {
+          // c.lui -> lui rd, imm
+          // (c.lui hints are translated into a lui hint)
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(15,io.instruction_i(12)), io.instruction_i(6,2), io.instruction_i(11,7), OPCODE_LUI)
+          
+          when(io.instruction_i(11,7) === "h02".asUInt(5.W)) {
+            // c.addi16sp -> addi x2, x2, nzimm
+             io.instruction_o := Cat(Fill(3,io.instruction_i(12)), io.instruction_i(4,3), io.instruction_i(5), io.instruction_i(2),
+                                  io.instruction_i(6), "b0000".asUInt(4.W), "h02".asUInt(5.W), "b000".asUInt(3.W), "h02".asUInt(5.W), OPCODE_OP_IMM)
+          }
+        }
+
+        is ("b100".U) {    
+
+          switch (io.instruction_i(11,10)) {
+
+            is ("b00".U) {
+              // c.srli -> srli rd, rd, shamt
+              io.is_comp := true.B
+              io.instruction_o := Cat("b0".U, io.instruction_i(10),"b00000".asUInt(5.W), io.instruction_i(6,2), "b01".asUInt(2.W), io.instruction_i(9,7),
+                                  "b101".asUInt(3.W),"b01".asUInt(2.W), io.instruction_i(9, 7), OPCODE_OP_IMM)
+            }
+
+            is ("b01".U) {
+              // c.srai -> srai rd, rd, shamt
+              io.is_comp := true.B
+              io.instruction_o := Cat("b0".U, io.instruction_i(10),"b00000".asUInt(5.W), io.instruction_i(6,2), "b01".asUInt(2.W), io.instruction_i(9,7),
+                                  "b101".asUInt(3.W),"b01".asUInt(2.W), io.instruction_i(9, 7), OPCODE_OP_IMM)
+            }              
+
+            is ("b10".U) {
+              // c.andi -> andi rd, rd, imm
+              io.is_comp := true.B
+              io.instruction_o := Cat(Fill(6,io.instruction_i(12)), io.instruction_i(12),io.instruction_i(6,2), "b01".asUInt(2.W), io.instruction_i(9,7),
+                                  "b111".asUInt(3.W),"b01".asUInt(2.W), io.instruction_i(9, 7), OPCODE_OP_IMM)
+            }
+
+            is ("b11".U) {
+
+              switch (io.instruction_i(6,5)) {
+
+                is ("b00".U) {
+                  // c.sub -> sub rd', rd', rs2'
+                  io.is_comp := true.B
+                  io.instruction_o := Cat("b01".asUInt(2.W), "b00000".asUInt(5.W), "b01".asUInt(2.W), io.instruction_i(4,2), "b01".asUInt(2.W),
+                                      io.instruction_i(9,7), "b000".asUInt(3.W), "b01".asUInt(2.W), io.instruction_i(9,7), OPCODE_OP)
+                }
+
+                is ("b01".U) {
+                  // c.xor -> xor rd', rd', rs2'
+                  io.is_comp := true.B
+                  io.instruction_o := Cat(Fill(7,"b0".U), "b01".asUInt(2.W), io.instruction_i(4,2), "b01".asUInt(2.W),
+                                      io.instruction_i(9,7), "b100".asUInt(3.W), "b01".asUInt(2.W), io.instruction_i(9,7), OPCODE_OP)
+                }
+
+                is ("b10".U) {
+                  // c.or  -> or  rd', rd', rs2'
+                  io.is_comp := true.B
+                  io.instruction_o := Cat(Fill(7,"b0".U), "b01".asUInt(2.W), io.instruction_i(4,2), "b01".asUInt(2.W),
+                                      io.instruction_i(9,7), "b110".asUInt(3.W), "b01".asUInt(2.W), io.instruction_i(9,7), OPCODE_OP)
+                }
+
+                is ("b11".U) {
+                  // c.and -> and rd', rd', rs2'
+                  io.is_comp := true.B
+                  io.instruction_o := Cat(Fill(7,"b0".U), "b01".asUInt(2.W), io.instruction_i(4,2), "b01".asUInt(2.W),
+                                      io.instruction_i(9,7), "b111".asUInt(3.W), "b01".asUInt(2.W), io.instruction_i(9,7), OPCODE_OP)
+                }
+              }
+            }
+          }
+        }
+
+        is ("b110".U) {
+          //c.beqz -> beq rs1', x0, imm
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(4,io.instruction_i(12)), io.instruction_i(6,5), io.instruction_i(2), Fill(5,"b0".U), "b01".asUInt(2.W),
+                              io.instruction_i(9,7), "b00".asUInt(2.W), io.instruction_i(13), io.instruction_i(11,10), io.instruction_i(4,3),
+                              io.instruction_i(12), OPCODE_BRANCH)
+        }
+
+        is ("b111".U) {
+          //c.bnez -> bne rs1', x0, imm
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(4,io.instruction_i(12)), io.instruction_i(6,5), io.instruction_i(2), Fill(5,"b0".U), "b01".asUInt(2.W),
+                              io.instruction_i(9,7), "b00".asUInt(2.W), io.instruction_i(13), io.instruction_i(11,10), io.instruction_i(4,3),
+                              io.instruction_i(12), OPCODE_BRANCH)
+        }
+      }
+    }
+
+    // C2
+
+    // Register address checks for RV32E are performed in the regular instruction decoder.
+    // If this check fails, an illegal instruction exception is triggered and the controller
+    // writes the actual faulting instruction to mtval.
+
+    is ("b10".U) {
+
+      switch (io.instruction_i(15,14)) {
+
+        is ("b00".U) {
+          // c.slli -> slli rd, rd, shamt
+          // (c.ssli hints are translated into a slli hint)
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(7,"b0".U), io.instruction_i(6,2), io.instruction_i(11,7), "b001".asUInt(3.W),
+                              io.instruction_i(11,7), OPCODE_OP_IMM)
+        }
+
+        is ("b01".U) {
+          // c.lwsp -> lw rd, imm(x2)
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(4,"b0".U), io.instruction_i(3,2), io.instruction_i(12), io.instruction_i(6,4), "b00".asUInt(2.W), "h02".U(5.W),
+                              "b010".asUInt(3.W), io.instruction_i(11,7), OPCODE_LOAD)
+        }
+
+        is ("b10".U) {
+
+          when(io.instruction_i(12) === "b0".U ) {
+
+            when(io.instruction_i(6,2) =/= "b0".asUInt(5.W)) {
+
+              // c.mv -> add rd/rs1, x0, rs2
+              // (c.mv hints are translated into an add hint)
+              io.is_comp := true.B
+              io.instruction_o := Cat(Fill(7,"b0".U), io.instruction_i(6,2),Fill(8,"b0".U), io.instruction_i(11,7), OPCODE_OP)
+            } .otherwise {
+
+               // c.jr -> jalr x0, rd/rs1, 0
+              io.is_comp := true.B
+              io.instruction_o := Cat(Fill(12,"b0".U), io.instruction_i(11,7),Fill(8,"b0".U), OPCODE_JALR)
+            }
+          } .otherwise {
+            
+            when(io.instruction_i(6,2) =/= "b0".asUInt(5.W)) {
+              // c.add -> add rd, rd, rs2
+              // (c.add hints are translated into an add hint)
+              io.is_comp := true.B
+              io.instruction_o := Cat(Fill(7,"b0".U), io.instruction_i(6,2), io.instruction_i(11,7), "b000".asUInt(3.W), io.instruction_i(11,7), OPCODE_OP)
+            } .otherwise {
+              
+              when(io.instruction_i(11,7) === "b0".asUInt(5.W)) {
+                // c.ebreak -> ebreak
+                io.is_comp := true.B
+                io.instruction_o := "h0010_0073".asUInt(32.W)
+              } .otherwise {
+                // c.jalr -> jalr x1, rs1, 0
+                io.is_comp := true.B
+                io.instruction_o := Cat(Fill(12,"b0".U), io.instruction_i(11,7),Fill(7,"b0".U), "b1".U, OPCODE_JALR)
+              }
+            }
+          }
+        }
+
+        is ("b11".U) {
+          // c.swsp -> sw rs2, imm(x2)
+          io.is_comp := true.B
+          io.instruction_o := Cat(Fill(4,"b0".U), io.instruction_i(8,7), io.instruction_i(12), io.instruction_i(6,2), "h02".asUInt(5.W), "b010".asUInt(3.W),
+                              io.instruction_i(11,9), "b00".asUInt(2.W), OPCODE_STORE)
+        }
+      }
+    }
+
+    is ("b11".U) {
+      // illegal instruction
+      io.is_comp := false.B
+      io.instruction_o := io.instruction_i
+
+    }
+  }
+  when(io.instruction_i === "h0".asUInt(32.W)){
+    // illegal instruction
+      io.is_comp := false.B
+      io.instruction_o := io.instruction_i
+  }
+}

--- a/src/main/scala/components/Core.scala
+++ b/src/main/scala/components/Core.scala
@@ -65,6 +65,7 @@ class Core(M:Boolean = false) extends Module {
 
   //Pipeline Units
   val IF = Module(new InstructionFetch).io
+  val CD = Module(new CompressedDecoder).io
   val ID = Module(new InstructionDecode).io
   val EX = Module(new Execute(M = M)).io
   val MEM = Module(new MemoryFetch)
@@ -75,10 +76,20 @@ class Core(M:Boolean = false) extends Module {
 
   val pc = Module(new PC)
 
-  val func3 = IF.instruction(14, 12)
+  io.imemReq <> IF.coreInstrReq
+  IF.coreInstrResp <> io.imemRsp
+  IF.address := pc.io.in.asUInt()
+
+  /*************************************************
+   * Compressed Decoder (Fully Combinational) *
+   *************************************************/
+  CD.instruction_i := IF.instruction
+  val instruction  = CD.instruction_o 
+
+  val func3 = instruction(14, 12)
   val func7 = Wire(UInt(6.W))
-  when(IF.instruction(6,0) === "b0110011".U){
-    func7 := IF.instruction(31,25)
+  when(instruction(6,0) === "b0110011".U){
+    func7 := instruction(31,25)
   }.otherwise{
     func7 := 0.U
   }
@@ -87,15 +98,9 @@ class Core(M:Boolean = false) extends Module {
 
   IF.stall := io.stall || EX.stall || ID.stall || IF_stall //stall signal from outside
   
-  io.imemReq <> IF.coreInstrReq
-  IF.coreInstrResp <> io.imemRsp
-
-  IF.address := pc.io.in.asUInt()
-  val instruction = IF.instruction
-
   // pc.io.halt := Mux(io.imemReq.valid || ~EX.stall || ~ID.stall, 0.B, 1.B)
   pc.io.halt := Mux(EX.stall || ID.stall || IF_stall || ~io.imemReq.valid, 1.B, 0.B)
-  pc.io.in := Mux(ID.hdu_pcWrite, Mux(ID.pcSrc, ID.pcPlusOffset.asSInt(), pc.io.pc4), pc.io.out)
+  pc.io.in := Mux(ID.hdu_pcWrite, Mux(ID.pcSrc, ID.pcPlusOffset.asSInt(), Mux(CD.is_comp, pc.io.pc2, pc.io.pc4)), pc.io.out)
 
   when(ID.hdu_if_reg_write) {
     if_reg_pc := pc.io.out.asUInt()

--- a/src/main/scala/components/InstructionDecode.scala
+++ b/src/main/scala/components/InstructionDecode.scala
@@ -185,7 +185,7 @@ class InstructionDecode extends Module {
 
   io.writeRegAddress := io.id_instruction(11, 7)
   io.func3 := io.id_instruction(14, 12)
-  when(io.id_instruction(6,0) === "b0110011".U){
+  when((io.id_instruction(6,0) === "b0110011".U) | ((io.id_instruction(6,0) === "b0010011".U) & (io.func3 === 5.U))){
     io.func7 := io.id_instruction(31,25)
   }.otherwise{
     io.func7 := 0.U

--- a/src/main/scala/components/PC.scala
+++ b/src/main/scala/components/PC.scala
@@ -7,10 +7,12 @@ class PC extends Module{
     val halt = Input(Bool())
     val out = Output(SInt(32.W))
     val pc4 = Output(SInt(32.W))
+    val pc2 = Output(SInt(32.W))
   })
 
   val pc_reg = RegInit((0x0-0x4).asSInt(32.W))
   pc_reg := io.in
   io.out := pc_reg
   io.pc4 := Mux(io.halt, pc_reg, pc_reg + 4.S)
+  io.pc2 := Mux(io.halt, pc_reg, pc_reg + 2.S)
 }

--- a/src/main/scala/components/Realigner.scala
+++ b/src/main/scala/components/Realigner.scala
@@ -1,0 +1,105 @@
+/*  
+    Created by @Abdulwadodd as part of Google Summer of Code program 2022.
+    
+    Description:
+    This module is instantiated in-between the InstructionFetch and rest of the core.
+    It receives instruction address (PC) from the core and the corresponding instruction from memory
+    If the Address is word aligned then it simply pass the signals b/w core and memory.
+    If the address is misaligned, then the state machine of Realigner module comes into action.
+    State machine performs the following operations:
+      1. Store the upper half word of current instruction,
+         Halt the PC for one cycle, and 
+         send the address to the next instruction.
+         Meanwhile, NOP will be fed to the core.
+      2. After one cycle, when the instruction arrives, 
+         the  lower half word of this instruction is concatenated
+         with the previously stored upper-half word. And this new 
+         instruction will be fed to the core.  */
+
+package nucleusrv.components
+import chisel3._
+import chisel3.util._ 
+
+class Realigner extends Module {
+  val io = IO(new Bundle {
+    //Input
+    val ral_address_i     = Input(UInt(32.W))
+    val ral_instruction_i = Input(UInt(32.W))
+    val ral_jmp           = Input(Bool())
+    // Outputs
+    val ral_address_o     = Output(UInt(32.W))
+    val ral_instruction_o = Output(UInt(32.W))
+    val ral_halt_o        = Output(Bool())
+  })
+
+  // 1st bit of address, which represents misalignment
+  val addri = io.ral_address_i(1)       
+  io.ral_halt_o := false.B
+
+  /* control signals */
+  val pc4_sel  = Wire(Bool())    
+  val conc_sel = Wire(Bool())   
+  val nop_sel  = Wire(Bool()) 
+  
+  pc4_sel := false.B    
+  conc_sel := false.B
+  nop_sel := false.B
+
+  // Register to store Lower half word
+  val lhw_reg = RegInit(0.U(16.W))     
+  val conc_instr = Wire(UInt(32.W)) 
+  lhw_reg := io.ral_instruction_i(31,16)
+  /* Concatenated Instruction: {real_instruction_i(15,0),lhw_reg} */
+  conc_instr := Cat(io.ral_instruction_i(15,0),lhw_reg)
+  
+  /* Address for InstructionFetch module */
+  io.ral_address_o := Mux(pc4_sel, io.ral_address_i + 4.U, io.ral_address_i)
+  
+  /* Instruction for the NRV core */  
+  io.ral_instruction_o := Mux(nop_sel, "h00000013".asUInt(32.W), Mux(conc_sel, conc_instr, io.ral_instruction_i))
+
+  /*****************
+   * Controller *
+   ******************/
+  // The three states
+  val state0 :: state1 :: state2 :: Nil = Enum (3)
+
+  // The state register
+  val stateReg = RegInit(state0)
+
+  // Next state logic
+  switch(stateReg){
+    is (state0) {
+      when (addri) {
+        stateReg := state1
+      }.otherwise{
+        stateReg := state0
+      }
+    }
+    is (state1) {
+      when(addri){
+        when (io.ral_jmp) {
+          stateReg := state1
+        }.otherwise{
+          stateReg := state2
+        }
+      }.otherwise {
+        stateReg := state0
+      }
+    }
+    is (state2) {
+      when (addri) {
+        stateReg := state1
+      }.otherwise{
+        stateReg := state0
+      }
+    }
+  }
+
+  // Output logic
+  io.ral_halt_o := (stateReg === state1)
+  pc4_sel       := (stateReg === state1) & addri & ~ (io.ral_jmp)
+  nop_sel       := (stateReg === state1)
+  conc_sel      := (stateReg === state2)
+
+}


### PR DESCRIPTION
The support of RISC-V Compressed extension has been added into NucleusRV core by @abdulwadoodd as part of Google Summer of Code 2022 under the mentorship of @usmnzain.
This project aims to deliver the following milestones.

- Design the hardware in CHISEL to support 25 Compressed instructions.
- Integrate the design with the NucleusRV core.
- Verify the NucleusRV for Compressed instructions using the RISC-V Compliance Test suite.
- Document the project.

## Design and Integration of C extension
The design and Integration of Compressed extension into NucleusRV - which is a 32-bit architecture core - is divided into the following steps.

### 1. Compressed Decoder
The first and foremost thing to have support for RISC-V Compressed extension is the design Compressed decoder. Since the NucleusRV is capable of processing 32-bit instructions. In order to process the compressed (16-bit) instructions, we need to have a decoder that takes compressed instruction and gives its 32-bit equivalent instruction.
The design of the Compressed decoder is based on the Compressed Instruction specification described in Chapter 16 of [RISC-V Unprivileged spec](https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf).
Compressed Decoder for NucleusRV core is implemented as part of [this](https://github.com/merledu/nucleusrv/pull/42/commits/09b8abbd35fd68017a07e939b04408c9fefeadf3) commit. This decoder is only active when the compressed instruction will encounter, otherwise, it will simply pass the input instruction to the output of the decoder. There is one addition signal `is_comp` that gets set only when compressed instruction is encountered.

### 2. Add support of Misaligned address (pc+2)
As the instruction memory of the NucleusRV core is byte aligned. In order to fetch the 32-bit instruction word, the Program counter (pc) must be incremented by 4. But with the support of Compressed (16-bit) instruction, the program counter must have the support to get incremented by 2 instead of 4. The increment of PC by 2 may cause misaligned instruction fetch - hence called it misaligned address - with which we will deal later on.
The support of misaligned instruction address is added into the NucleusRV core as part of [this](https://github.com/merledu/nucleusrv/pull/42/commits/79f6c53790966d35c4e735d412263b217221dd6e) commit. By default, pc will increment by 4 for non-branching and non-jumping instructions. But whenever the compressed instruction will be encountered, the `is_comp` signal will be set and based on this signal, the pc is incremented by 2.

### 3. Realigner: Handling misaligned Instructions
As discussed in the previous step, the pc+2 causes the misaligned instruction fetch. So, the most important and challenging part of this is handling misaligned instructions and feeding the correct instructions to the core. 
This `Realigner` module is instantiated in between the InstructionFetch module and the rest of the core. It receives the instruction address (PC) from the core and the corresponding instruction from memory. The support of the Realigner module is integrated as part of [this](https://github.com/merledu/nucleusrv/pull/42/commits/ad32aa60868cf591921cc20306b6c5847ee83cf7) commit.
If the instruction address is word aligned then Realigner will simply pass the signals between core and memory. If the pc is misaligned (pc%4 != 0), then the state machine of the Realigner module comes into action. State machine performs the following operations:

1. Store the upper half-word of current instruction,
    Halt the PC for one cycle, and
    send the address to the next instruction.
    Meanwhile, NOP will be fed to the core.

2. After one cycle, when the instruction arrives, 
    the lower half-word of this instruction is concatenated
    with the previously stored upper-half word. And this new 
    instruction will be fed to the core.

Implementing these 3 steps successfully concludes the integration of Compressed Extension support in NucleusRV.

## Bug Fixing
There was a bug in NucleusRV that breaks the `SRAI` instruction. This was fixed as part of [this](https://github.com/merledu/nucleusrv/pull/42/commits/8f00056457407b623361c9cb2b4dc2e090f3559c) commit.

## Verification
The integrated Compressed instructions are verified using [RISC-V Compliance test suite](https://github.com/riscv-non-isa/riscv-arch-test/tree/main/riscv-test-suite/rv32i_m/C/src). The instructions for running the compliance test are given [here](https://github.com/merledu/nucleusrv/tree/no-deps#:~:text=Running%20Compliance%20Tests).
All the tests for the required 25 Compressed instructions are passed on NucleusRV. The results are given below.
```
Compare to reference files ... 

Check               C-ADDI16SP ... OK
Check               C-ADDI4SPN ... OK
Check                   C-ADDI ... OK
Check                    C-ADD ... OK
Check                   C-ANDI ... OK
Check                    C-AND ... OK
Check                   C-BEQZ ... OK
Check                   C-BNEZ ... OK
Check                    C-JAL ... OK
Check                   C-JALR ... OK
Check                      C-J ... OK
Check                     C-JR ... OK
Check                     C-LI ... OK
Check                    C-LUI ... OK
Check                     C-LW ... OK
Check                   C-LWSP ... OK
Check                     C-MV ... OK
Check                     C-OR ... OK
Check                   C-SLLI ... OK
Check                   C-SRAI ... OK
Check                   C-SRLI ... OK
Check                    C-SUB ... OK
Check                     C-SW ... OK
Check                   C-SWSP ... OK
Check                    C-XOR ... OK
--------------------------------
OK: 25/25 RISCV_TARGET=nucleusrv RISCV_DEVICE=rv32i RISCV_ISA=rv32imc
```
## Conclusion
The support of Compressed instruction makes better utilization of memory. Instruction size in the memory is reduced by half but we have to put extra hardware for decoding to support the compressed instruction. [This](https://medium.com/@abdulwadoodd/risc-v-compressed-instructions-for-serv-6065f55158b4) blog explains more about RISC-V Compressed extension.