### PR TITLE
fix: prevent false-positive test results on signature length mismatch

### DIFF
--- a/manual_run_riscv_arch_test.py
+++ b/manual_run_riscv_arch_test.py
@@ -53,14 +53,14 @@ def simulate_and_compare(testlist, test, f):
     if len(nrv_sig) != len(ref_sig):
         f.write(f'| {test_name:30} | {"Failed"} |\n')
         f.flush()
-    for i in range(min((len(nrv_sig), len(ref_sig)))):
+        return
+    for i in range(len(nrv_sig)):
         if nrv_sig[i] != ref_sig[i]:
             f.write(f'| {test_name:30} | {"Failed"} |\n')
             f.flush()
-            break
-    else:
-        f.write(f'| {test_name:30} | {"Passed"} |\n')
-        f.flush()
+            return
+    f.write(f'| {test_name:30} | {"Passed"} |\n')
+    f.flush()
 
 if __name__ == '__main__':
     parser = ArgumentParser()


### PR DESCRIPTION
## Problem

In `manual_run_riscv_arch_test.py`, when the DUT signature and the
Spike reference signature have different lengths, the comparison
function writes "Failed" to the log but does not return early.

Execution falls through into the `for-else` loop (line 56-63), which
iterates over `min(len(nrv_sig), len(ref_sig))`. If the shorter
prefix happens to match, the loop completes without `break`, and
Python's `for-else` semantics trigger the `else` block — writing
"Passed" for the same test that was already marked "Failed".

This means a test where the core produces a truncated or extended
signature can silently appear as "Passed" in the final report.

## Fix

- Added an early `return` after the length-mismatch check.
- Replaced the `for-else` pattern with explicit `return` statements
  to make the control flow unambiguous.
- Used `range(len(nrv_sig))` instead of `range(min(...))` since
  lengths are now guaranteed equal at that point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved test validation to immediately flag signature mismatches, ensuring faster failure detection and more accurate test result reporting in RISC-V architecture testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->